### PR TITLE
fix: improve export templates command

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,18 @@ You can list the available templates using the `list-templates` command:
 npx codewhisper list-templates
 ```
 
+### Export Example Templates
+
+You can export the built-in templates to a specified directory:
+
+```bash
+npx codewhisper export-templates -d /path/to/export/directory
+```
+
+Options:
+
+* `-d, --dir <directory>`: Target directory for exported templates
+
 ### Typical Usage Examples
 
 01. Include only JavaScript and TypeScript files:

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -191,7 +191,16 @@ export function cli(args: string[]) {
 
       try {
         await fs.ensureDir(targetDir);
-        await fs.copy(templatesDir, targetDir, { overwrite: false });
+
+        const templateFiles = await fs.readdir(templatesDir);
+        const hbsFiles = templateFiles.filter((file) => file.endsWith('.hbs'));
+
+        for (const file of hbsFiles) {
+          const srcPath = path.join(templatesDir, file);
+          const destPath = path.join(targetDir, file);
+          await fs.copy(srcPath, destPath, { overwrite: false });
+        }
+
         console.log(chalk.green(`Templates exported to ${targetDir}`));
       } catch (error) {
         console.error(


### PR DESCRIPTION
When running from a global installation (or npx) CodeWhisper was exporting the entire contents of the dist folder

- add more usage examples to README
- add the export-templates command documentation to README