### PR TITLE
fix: branch name sanitization

### DIFF
--- a/src/interactive/select-github-issue-prompt.ts
+++ b/src/interactive/select-github-issue-prompt.ts
@@ -22,6 +22,7 @@ export async function selectGitHubIssuePrompt(): Promise<GitHubIssue | null> {
     }
 
     const selectedIssueNumber = await select({
+      pageSize: 10,
       message: 'Select a GitHub issue:',
       choices: issues.map((issue) => ({
         name: `#${issue.number} - ${issue.title}`,

--- a/tests/unit/git-tools.test.ts
+++ b/tests/unit/git-tools.test.ts
@@ -85,7 +85,7 @@ describe('ensureBranch', () => {
 
     await expect(
       ensureBranch(mockBasePath, 'feature/new-branch'),
-    ).rejects.toThrow('Branch creation failed');
+    ).rejects.toThrow('Failed to create branch feature/new-branch');
     expect(mockGit.branchLocal).toHaveBeenCalledTimes(1);
     expect(mockGit.checkoutLocalBranch).toHaveBeenCalledWith(
       'feature/new-branch',

--- a/tests/unit/parse-ai-codegen-response.test.ts
+++ b/tests/unit/parse-ai-codegen-response.test.ts
@@ -184,6 +184,18 @@ console.log('Hello, World!');
     expect(result.gitBranchName).toBe('invalid/branch/name----------');
   });
 
+  it('should sanitize invalid branch names with a leading slash', () => {
+    const mockResponse = `
+<file_list></file_list>
+<git_branch_name>/feature/invalid-branch-name-issue-123</git_branch_name>
+<git_commit_message>Some commit message</git_commit_message>
+`;
+
+    const result = parseAICodegenResponse(mockResponse);
+
+    expect(result.gitBranchName).toBe('feature/invalid-branch-name-issue-123');
+  });
+
   it('should provide a default branch name when sanitized name is empty', () => {
     const mockResponse = `
 <file_list></file_list>


### PR DESCRIPTION
This PR fixes a bug with a leading slash being added to the git branch name if using the GitHub Issues integration.

- removed the leading slash
- added extra validation for github branch names
- added a test to cover the new validation

fixes #43