### PR TITLE
feat: Add --redo functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ ElPlan.md
 ElPlanFilter.md
 codewhisper-task-output.json
 demotask.md
+.codewhisper-task-cache.json

--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ codewhisper task -m ollama:llama3.1:70b --context-window 131072 --max-tokens 819
 
 # To undo changes made by an AI-assisted task, use the --undo option
 codewhisper task --undo
+
+# To redo the last task with the option to change the model, file selection or plan, use the --redo option
+codewhisper task --redo
 ```
 
 > Note: If you are using CodeWhisper's LLM integration with `codewhisper task` you will need to set the respective environment variable for the model you want to use (e.g. `export ANTHROPIC_API_KEY=your_api_key` or `export OPENAI_API_KEY=your_api_key` or `export GROQ_API_KEY=your_api_key` ).
@@ -281,6 +284,43 @@ This command will:
 The command will always ask for confirmation before making any changes. It will show you the exact actions it's about to perform, including the full commit message of any commit it's about to revert.
 
 Always review the proposed changes carefully before confirming, as this operation may result in loss of work.
+
+Here's the updated section for the README.md file that includes information about the new --redo functionality:
+
+### Redoing AI-Assisted Tasks
+
+CodeWhisper now supports redoing AI-assisted tasks from the review plan stage. This feature allows you to restart your last task with the option to modify the generated plan as well as the model and file selection. To use this feature, you can use the `--redo` option with the `task` command:
+
+```bash
+codewhisper task --redo
+```
+
+When you use the `--redo` option:
+
+1. CodeWhisper will retrieve the last task data for the current project directory.
+2. It will display the details of the last task, including the task description, instructions, model used, and files included.
+3. You'll be given the option to change the AI model for code generation.
+4. You'll also have the opportunity to modify the file selection for the task.
+5. The task will then continue from the review plan stage, where you can then modify the plan to your liking.
+
+This feature is particularly useful when:
+- You want to try a different AI model for the same task
+- You need to adjust the file selection for the same task
+- You want to quickly tweak the plan without starting from scratch
+
+Note: The redo functionality uses a cache stored in your home directory, so it persists across different sessions and is not affected by git operations like branch switching or resetting.
+
+Example workflow:
+
+1. Run an initial task: `codewhisper task`
+2. Review the code modifications and decide you want to tweak the plan or try a different model
+3. Undo the task: `codewhisper task --undo`
+3. Redo the task: `codewhisper task --redo`
+4. Optionally change the model when prompted
+5. Optionally adjust the file selection
+6. Adjust the plan as needed
+
+This feature enhances the flexibility of CodeWhisper's AI-assisted workflow, allowing for quick iterations and experimentation with different models or scopes for your tasks.
 
 ## 📝 Templates
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -63,6 +63,7 @@ codewhisper task [options]
 | `-max, --max-cost-threshold <number>` | Set a maximum cost threshold for AI operations in USD (e.g., 0.5 for $0.50)                                                                                    |
 | `--auto-commit`                       | Automatically commit changes                                                                                                                                   |
 | `--undo`                              | Undo AI-assisted task changes                                                                                                                                  |
+| `--redo`                              | Redo the last task for the specified path with the option to change the generated plan as well as the model and file selection (see below)                 |
 
 #### Model Selection
 
@@ -365,6 +366,37 @@ This command will:
 - Offer to revert the last commit if on the main branch
 
 The command will always ask for confirmation before making any changes.
+
+25. Redo the last task with the option to change the generated plan as well as the model and file selection:
+
+```bash
+codewhisper task --redo
+```
+
+This command will:
+
+- Retrieve the last task data for the current project directory
+- Display the details of the last task, including the task description, instructions, model used, and files included
+- You'll be given the option to change the AI model for code generation
+- You'll also have the opportunity to modify the file selection for the task
+- The task will then continue from the review plan stage, where you can then modify the plan to your liking
+
+This feature is particularly useful when:
+- You want to try a different AI model for the same task
+- You need to adjust the file selection for the same task
+- You want to quickly tweak the plan without starting from scratch
+
+Note: The redo functionality uses a cache stored in your home directory, so it persists across different sessions and is not affected by git operations like branch switching or resetting.
+
+Example workflow:
+
+1. Run an initial task: `codewhisper task`
+2. Review the code modifications and decide you want to tweak the plan or try a different model
+3. Undo the task: `codewhisper task --undo`
+3. Redo the task: `codewhisper task --redo`
+4. Optionally change the model when prompted
+5. Optionally adjust the file selection
+6. Adjust the plan as needed
 
 ## CI/CD Integration
 

--- a/src/ai/redo-task.ts
+++ b/src/ai/redo-task.ts
@@ -13,9 +13,7 @@ export async function redoLastTask(options: AiAssistedTaskOptions) {
   const spinner = ora();
   try {
     const basePath = path.resolve(options.path ?? '.');
-    const taskCache = new TaskCache(
-      path.join(basePath, '.codewhisper-task-cache.json'),
-    );
+    const taskCache = new TaskCache(basePath);
 
     const lastTaskData = taskCache.getLastTaskData(basePath);
 

--- a/src/ai/redo-task.ts
+++ b/src/ai/redo-task.ts
@@ -1,0 +1,96 @@
+import path from 'node:path';
+import { confirm } from '@inquirer/prompts';
+import chalk from 'chalk';
+import ora from 'ora';
+import { selectFilesPrompt } from '../interactive/select-files-prompt';
+import { selectModelPrompt } from '../interactive/select-model-prompt';
+import type { AiAssistedTaskOptions } from '../types';
+import { TaskCache } from '../utils/task-cache';
+import { getModelConfig } from './model-config';
+import { continueTaskWorkflow } from './task-workflow';
+
+export async function redoLastTask(options: AiAssistedTaskOptions) {
+  const spinner = ora();
+  try {
+    const basePath = path.resolve(options.path ?? '.');
+    const taskCache = new TaskCache(
+      path.join(basePath, '.codewhisper-task-cache.json'),
+    );
+
+    const lastTaskData = taskCache.getLastTaskData(basePath);
+
+    if (!lastTaskData) {
+      console.log(
+        chalk.yellow(
+          'No previous task found for this directory. Please run a new task.',
+        ),
+      );
+      process.exit(0);
+    }
+
+    console.log(chalk.blue('Redoing last task:'));
+    console.log(chalk.cyan('Task Description:'), lastTaskData.taskDescription);
+    console.log(chalk.cyan('Instructions:'), lastTaskData.instructions);
+    console.log(chalk.cyan('Model:'), lastTaskData.model);
+    console.log(chalk.cyan('Files included:'));
+    for (const file of lastTaskData.selectedFiles) {
+      console.log(chalk.cyan(`  ${file}`));
+    }
+
+    let modelKey = lastTaskData.model || options.model;
+    let selectedFiles = lastTaskData.selectedFiles;
+
+    // Confirmation for changing the model
+    const changeModel = await confirm({
+      message: 'Do you want to change the AI model for code generation?',
+      default: false,
+    });
+
+    if (changeModel) {
+      modelKey = await selectModelPrompt();
+      console.log(
+        chalk.blue(`Using new model: ${getModelConfig(modelKey).modelName}`),
+      );
+    }
+
+    // Confirmation for changing file selection
+    const changeFiles = await confirm({
+      message: 'Do you want to change the file selection for code generation?',
+      default: false,
+    });
+
+    if (changeFiles) {
+      selectedFiles = await selectFilesPrompt(
+        basePath,
+        options.invert ?? false,
+      );
+      console.log(chalk.cyan('New file selection:'));
+      for (const file of selectedFiles) {
+        console.log(chalk.cyan(`  ${file}`));
+      }
+    }
+
+    // Update the task cache with new selections if changed
+    if (changeModel || changeFiles) {
+      taskCache.setTaskData(basePath, {
+        ...lastTaskData,
+        model: modelKey,
+        selectedFiles,
+      });
+    }
+
+    await continueTaskWorkflow(
+      { ...options, model: modelKey },
+      basePath,
+      taskCache,
+      lastTaskData.generatedPlan,
+      modelKey,
+    );
+  } catch (error) {
+    spinner.fail('Error in redoing AI-assisted task');
+    console.error(
+      chalk.red(error instanceof Error ? error.message : String(error)),
+    );
+    process.exit(1);
+  }
+}

--- a/src/ai/task-workflow.ts
+++ b/src/ai/task-workflow.ts
@@ -38,9 +38,7 @@ export async function runAIAssistedTask(options: AiAssistedTaskOptions) {
   const spinner = ora();
   try {
     const basePath = path.resolve(options.path ?? '.');
-    const taskCache = new TaskCache(
-      path.join(basePath, '.codewhisper-task-cache.json'),
-    );
+    const taskCache = new TaskCache(basePath);
 
     const modelKey = await selectModel(options);
     const { taskDescription, instructions } = await getTaskInfo(

--- a/src/ai/task-workflow.ts
+++ b/src/ai/task-workflow.ts
@@ -9,13 +9,19 @@ import { applyChanges } from '../git/apply-changes';
 import { selectFilesPrompt } from '../interactive/select-files-prompt';
 import { selectGitHubIssuePrompt } from '../interactive/select-github-issue-prompt';
 import { selectModelPrompt } from '../interactive/select-model-prompt';
-import type { AiAssistedTaskOptions, MarkdownOptions } from '../types';
+import type {
+  AIParsedResponse,
+  AiAssistedTaskOptions,
+  FileInfo,
+  MarkdownOptions,
+} from '../types';
 import {
   DEFAULT_CACHE_PATH,
   getCachedValue,
   setCachedValue,
 } from '../utils/cache-utils';
 import { ensureBranch } from '../utils/git-tools';
+import { TaskCache } from '../utils/task-cache';
 import {
   collectVariables,
   extractTemplateVariables,
@@ -32,386 +38,510 @@ export async function runAIAssistedTask(options: AiAssistedTaskOptions) {
   const spinner = ora();
   try {
     const basePath = path.resolve(options.path ?? '.');
-
-    // Model selection
-    let modelKey = options.model;
-
-    if (modelKey) {
-      const modelConfig = getModelConfig(options.model);
-      if (!modelConfig) {
-        console.log(chalk.red(`Invalid model ID: ${options.model}.`));
-        console.log(chalk.yellow('Displaying model selection list...'));
-      } else {
-        console.log(chalk.blue(`Using model: ${modelConfig.modelName}`));
-      }
-    }
-
-    if (!modelKey) {
-      try {
-        modelKey = await selectModelPrompt();
-        const modelConfig = getModelConfig(modelKey);
-        console.log(chalk.blue(`Using model: ${modelConfig.modelName}`));
-      } catch (error) {
-        console.error(chalk.red('Error selecting model:'), error);
-        process.exit(1);
-      }
-    }
-
-    let taskDescription = '';
-    let instructions = '';
-
-    if (options.githubIssue) {
-      if (!process.env.GITHUB_TOKEN) {
-        console.log(
-          chalk.yellow(
-            'GITHUB_TOKEN not set. GitHub issue functionality may be limited.',
-          ),
-        );
-      }
-      const selectedIssue = await selectGitHubIssuePrompt(basePath);
-      if (selectedIssue) {
-        taskDescription = `# ${selectedIssue.title}\n\n${selectedIssue.body}`;
-        options.issueNumber = selectedIssue.number;
-      } else {
-        console.log(
-          chalk.yellow(
-            'No GitHub issue selected. Falling back to manual input.',
-          ),
-        );
-      }
-    }
-
-    if (!taskDescription) {
-      if (options.task || options.description) {
-        taskDescription =
-          `# ${options.task || 'Task'}\n\n${options.description || ''}`.trim();
-      } else {
-        const cachedTaskDescription = await getCachedValue(
-          'taskDescription',
-          options.cachePath,
-        );
-        if (cachedTaskDescription) {
-          console.log(chalk.yellow('Using cached task description.'));
-        }
-        taskDescription =
-          (await getTaskDescription(
-            cachedTaskDescription as string | undefined,
-          )) ?? 'No task description provided.';
-        await setCachedValue(
-          'taskDescription',
-          taskDescription,
-          options.cachePath,
-        );
-      }
-    }
-
-    if (!instructions) {
-      if (options.instructions) {
-        instructions = options.instructions;
-      } else {
-        const cachedInstructions = await getCachedValue(
-          'instructions',
-          options.cachePath,
-        );
-        if (cachedInstructions) {
-          console.log(chalk.yellow('Using cached instructions.'));
-        }
-        instructions =
-          (await getInstructions(cachedInstructions as string | undefined)) ??
-          'No instructions provided.';
-        await setCachedValue('instructions', instructions, options.cachePath);
-      }
-    }
-
-    const userFilters = options.filter || [];
-
-    let selectedFiles: string[];
-    if (options.context && options.context.length > 0) {
-      selectedFiles = options.context.map((item) => {
-        const relativePath = path.relative(basePath, item);
-        return fs.statSync(path.join(basePath, item)).isDirectory()
-          ? path.join(relativePath, '**/*')
-          : relativePath;
-      });
-    } else {
-      selectedFiles = await selectFilesPrompt(
-        basePath,
-        options.invert ?? false,
-      );
-    }
-    // Combine user filters with selected files
-    const combinedFilters = [...new Set([...userFilters, ...selectedFiles])];
-
-    console.log(
-      chalk.cyan(`Files to be ${options.invert ? 'excluded' : 'included'}:`),
+    const taskCache = new TaskCache(
+      path.join(basePath, '.codewhisper-task-cache.json'),
     );
-    for (const filter of combinedFilters) {
-      console.log(chalk.cyan(`  ${filter}`));
-    }
+
+    const modelKey = await selectModel(options);
+    const { taskDescription, instructions } = await getTaskInfo(
+      options,
+      basePath,
+    );
+    const selectedFiles = await selectFiles(options, basePath);
 
     const templatePath = getTemplatePath('task-plan-prompt');
-
     const templateContent = await fs.readFile(templatePath, 'utf-8');
-    const variables = extractTemplateVariables(templateContent);
-
-    const dataObj = {
-      var_taskDescription: taskDescription,
-      var_instructions: instructions,
-    };
-
-    let data: string;
-    try {
-      data = JSON.stringify(dataObj);
-    } catch (error) {
-      console.error(
-        chalk.red('Error creating data for task plan prompt:'),
-        error instanceof Error ? error.message : String(error),
-      );
-      process.exit(1);
-    }
-
-    const customData = await collectVariables(
-      data,
-      options.cachePath ?? DEFAULT_CACHE_PATH,
-      variables,
-      templatePath,
+    const customData = await prepareCustomData(
+      templateContent,
+      taskDescription,
+      instructions,
+      options,
     );
 
     spinner.start('Processing files...');
-    const processedFiles = await processFiles({
-      ...options,
-      path: basePath,
-      filter: options.invert ? undefined : combinedFilters,
-      exclude: options.invert ? combinedFilters : options.exclude,
-    });
+    const processedFiles = await processFiles(
+      getProcessOptions(options, basePath, selectedFiles),
+    );
     spinner.succeed('Files processed successfully');
 
-    spinner.start('Generating markdown...');
-    const markdownOptions: MarkdownOptions = {
-      noCodeblock: options.noCodeblock,
-      basePath,
-      customData,
-      lineNumbers: options.lineNumbers,
-    };
-
-    const planPrompt = await generateMarkdown(
+    const planPrompt = await generatePlanPrompt(
       processedFiles,
       templateContent,
-      markdownOptions,
-    );
-    spinner.succeed('Plan prompt generated successfully');
-
-    const modelConfig = getModelConfig(modelKey);
-
-    spinner.start('Generating AI plan...');
-    let generatedPlan: string;
-    if (modelKey.includes('ollama')) {
-      generatedPlan = await generateAIResponse(planPrompt, {
-        maxCostThreshold: options.maxCostThreshold,
-        model: modelKey,
-        contextWindow: options.contextWindow,
-        maxTokens: options.maxTokens,
-        logAiInteractions: options.logAiInteractions,
-      });
-    } else {
-      generatedPlan = await generateAIResponse(
-        planPrompt,
-        {
-          maxCostThreshold: options.maxCostThreshold,
-          model: modelKey,
-          logAiInteractions: options.logAiInteractions,
-        },
-        modelConfig.temperature?.planningTemperature,
-      );
-    }
-
-    spinner.succeed('AI plan generated successfully');
-
-    const reviewedPlan = await reviewPlan(generatedPlan);
-
-    let codegenTemplatePath: string;
-
-    if (options.diff) {
-      codegenTemplatePath = getTemplatePath('codegen-diff-prompt');
-    } else {
-      codegenTemplatePath = getTemplatePath('codegen-prompt');
-    }
-
-    const codegenTemplateContent = await fs.readFile(
-      codegenTemplatePath,
-      'utf-8',
-    );
-
-    const codegenVariables = extractTemplateVariables(codegenTemplateContent);
-
-    const codegenDataObj = {
-      var_taskDescription: taskDescription,
-      var_instructions: instructions,
-      var_plan: reviewedPlan,
-    };
-
-    let codegenData: string;
-    try {
-      codegenData = JSON.stringify(codegenDataObj);
-    } catch (error) {
-      console.error(
-        chalk.red('Error creating data for code generation prompt:'),
-        error instanceof Error ? error.message : String(error),
-      );
-      process.exit(1);
-    }
-
-    const codegenCustomData = await collectVariables(
-      codegenData,
-      options.cachePath ?? DEFAULT_CACHE_PATH,
-      codegenVariables,
-      codegenTemplatePath,
-    );
-
-    spinner.start('Generating Codegen prompt...');
-    const codegenMarkdownOptions: MarkdownOptions = {
-      noCodeblock: options.noCodeblock,
+      customData,
+      options,
       basePath,
-      customData: codegenCustomData,
-      lineNumbers: options.lineNumbers,
-    };
-
-    const codeGenPrompt = await generateMarkdown(
-      processedFiles,
-      codegenTemplateContent,
-      codegenMarkdownOptions,
-    );
-    spinner.succeed('Codegen prompt generated successfully');
-
-    spinner.start('Generating AI Code Modifications...');
-    let generatedCode: string;
-    if (modelKey.includes('ollama')) {
-      generatedCode = await generateAIResponse(codeGenPrompt, {
-        maxCostThreshold: options.maxCostThreshold,
-        model: modelKey,
-        contextWindow: options.contextWindow,
-        maxTokens: options.maxTokens,
-        logAiInteractions: options.logAiInteractions,
-      });
-    } else {
-      generatedCode = await generateAIResponse(
-        codeGenPrompt,
-        {
-          maxCostThreshold: options.maxCostThreshold,
-          model: modelKey,
-          logAiInteractions: options.logAiInteractions,
-        },
-        modelConfig.temperature?.codegenTemperature,
-      );
-    }
-    spinner.succeed('AI Code Modifications generated successfully');
-
-    const parsedResponse = parseAICodegenResponse(
-      generatedCode,
-      options.logAiInteractions,
-      options.diff,
     );
 
-    if (options.dryRun) {
-      spinner.info(
-        chalk.yellow(
-          'Dry Run Mode: Generating output without applying changes',
-        ),
-      );
+    const generatedPlan = await generatePlan(planPrompt, modelKey, options);
 
-      // Save only the generated code modifications
-      const outputPath = path.join(basePath, 'codewhisper-task-output.json');
-      await fs.writeJSON(
-        outputPath,
-        {
-          taskDescription,
-          parsedResponse,
-        },
-        { spaces: 2 },
-      );
-      console.log(chalk.green(`AI-generated output saved to: ${outputPath}`));
-      console.log(chalk.cyan('To apply these changes, run:'));
-      console.log(chalk.cyan(`npx codewhisper apply-task ${outputPath}`));
+    // Cache the task data
+    taskCache.setTaskData(basePath, {
+      selectedFiles,
+      generatedPlan,
+      taskDescription,
+      instructions,
+      model: modelKey,
+    });
 
-      // Detailed console output
-      console.log('\nTask Summary:');
-      console.log(chalk.blue('Task Description:'), taskDescription);
-      console.log(chalk.blue('Branch Name:'), parsedResponse.gitBranchName);
-      console.log(
-        chalk.blue('Commit Message:'),
-        parsedResponse.gitCommitMessage,
-      );
-      console.log(chalk.blue('Files to be changed:'));
-      for (const file of parsedResponse.files) {
-        console.log(`  ${file.status}: ${file.path}`);
-      }
-      console.log(chalk.blue('Summary:'), parsedResponse.summary);
-      console.log(
-        chalk.blue('Potential Issues:'),
-        parsedResponse.potentialIssues,
-      );
-    } else {
-      spinner.start('Applying AI Code Modifications...');
-
-      try {
-        const actualBranchName = await ensureBranch(
-          basePath,
-          parsedResponse.gitBranchName,
-          { issueNumber: options.issueNumber },
-        );
-
-        // Apply changes
-        await applyChanges({ basePath, parsedResponse, dryRun: false });
-
-        if (options.autoCommit) {
-          const git = simpleGit(basePath);
-          await git.add('.');
-          const commitMessage = options.issueNumber
-            ? `${parsedResponse.gitCommitMessage} (Closes #${options.issueNumber})`
-            : parsedResponse.gitCommitMessage;
-          await git.commit(commitMessage);
-          spinner.succeed(
-            `AI Code Modifications applied and committed to branch: ${actualBranchName}`,
-          );
-        } else {
-          spinner.succeed(
-            `AI Code Modifications applied to branch: ${actualBranchName}`,
-          );
-          console.log(
-            chalk.green('Changes have been applied but not committed.'),
-          );
-          console.log(
-            chalk.yellow(
-              'Please review the changes in your IDE before committing.',
-            ),
-          );
-          console.log(
-            chalk.cyan('To commit the changes, use the following commands:'),
-          );
-          console.log(chalk.cyan('  git add .'));
-          console.log(
-            chalk.cyan(
-              `  git commit -m "${parsedResponse.gitCommitMessage}${options.issueNumber ? ` (Closes #${options.issueNumber})` : ''}"`,
-            ),
-          );
-        }
-      } catch (error) {
-        spinner.fail('Error applying AI Code Modifications');
-        console.error(
-          chalk.red('Failed to create branch or apply changes:'),
-          error instanceof Error ? error.message : String(error),
-        );
-        console.log(
-          chalk.yellow('Please check your Git configuration and try again.'),
-        );
-        process.exit(1);
-      }
-    }
-    console.log(chalk.green('AI-assisted task completed! 🎉'));
+    await continueTaskWorkflow(
+      options,
+      basePath,
+      taskCache,
+      generatedPlan,
+      modelKey,
+    );
   } catch (error) {
     spinner.fail('Error in AI-assisted task');
     console.error(
       chalk.red(error instanceof Error ? error.message : String(error)),
+    );
+    process.exit(1);
+  }
+}
+
+async function selectModel(options: AiAssistedTaskOptions): Promise<string> {
+  let modelKey = options.model;
+
+  if (modelKey) {
+    const modelConfig = getModelConfig(modelKey);
+    if (!modelConfig) {
+      console.log(chalk.red(`Invalid model ID: ${modelKey}.`));
+      console.log(chalk.yellow('Displaying model selection list...'));
+      modelKey = '';
+    } else {
+      console.log(chalk.blue(`Using model: ${modelConfig.modelName}`));
+    }
+  }
+
+  if (!modelKey) {
+    try {
+      modelKey = await selectModelPrompt();
+      const modelConfig = getModelConfig(modelKey);
+      console.log(chalk.blue(`Using model: ${modelConfig.modelName}`));
+    } catch (error) {
+      console.error(chalk.red('Error selecting model:'), error);
+      process.exit(1);
+    }
+  }
+
+  return modelKey;
+}
+
+async function getTaskInfo(
+  options: AiAssistedTaskOptions,
+  basePath: string,
+): Promise<{ taskDescription: string; instructions: string }> {
+  let taskDescription = '';
+  let instructions = '';
+
+  if (options.githubIssue) {
+    if (!process.env.GITHUB_TOKEN) {
+      console.log(
+        chalk.yellow(
+          'GITHUB_TOKEN not set. GitHub issue functionality may be limited.',
+        ),
+      );
+    }
+    const selectedIssue = await selectGitHubIssuePrompt(basePath);
+    if (selectedIssue) {
+      taskDescription = `# ${selectedIssue.title}\n\n${selectedIssue.body}`;
+      options.issueNumber = selectedIssue.number;
+    } else {
+      console.log(
+        chalk.yellow('No GitHub issue selected. Falling back to manual input.'),
+      );
+    }
+  }
+
+  if (!taskDescription) {
+    if (options.task || options.description) {
+      taskDescription =
+        `# ${options.task || 'Task'}\n\n${options.description || ''}`.trim();
+    } else {
+      const cachedTaskDescription = await getCachedValue(
+        'taskDescription',
+        options.cachePath,
+      );
+      taskDescription = await getTaskDescription(
+        cachedTaskDescription as string | undefined,
+      );
+      await setCachedValue(
+        'taskDescription',
+        taskDescription,
+        options.cachePath,
+      );
+    }
+  }
+
+  if (!instructions) {
+    if (options.instructions) {
+      instructions = options.instructions;
+    } else {
+      const cachedInstructions = await getCachedValue(
+        'instructions',
+        options.cachePath,
+      );
+      instructions = await getInstructions(
+        cachedInstructions as string | undefined,
+      );
+      await setCachedValue('instructions', instructions, options.cachePath);
+    }
+  }
+
+  return { taskDescription, instructions };
+}
+
+async function selectFiles(
+  options: AiAssistedTaskOptions,
+  basePath: string,
+): Promise<string[]> {
+  const userFilters = options.filter || [];
+
+  let selectedFiles: string[];
+  if (options.context && options.context.length > 0) {
+    selectedFiles = options.context.map((item) => {
+      const relativePath = path.relative(basePath, item);
+      return fs.statSync(path.join(basePath, item)).isDirectory()
+        ? path.join(relativePath, '**/*')
+        : relativePath;
+    });
+  } else {
+    selectedFiles = await selectFilesPrompt(basePath, options.invert ?? false);
+  }
+
+  const combinedFilters = [...new Set([...userFilters, ...selectedFiles])];
+
+  console.log(
+    chalk.cyan(`Files to be ${options.invert ? 'excluded' : 'included'}:`),
+  );
+  for (const filter of combinedFilters) {
+    console.log(chalk.cyan(`  ${filter}`));
+  }
+
+  return combinedFilters;
+}
+
+async function prepareCustomData(
+  templateContent: string,
+  taskDescription: string,
+  instructions: string,
+  options: AiAssistedTaskOptions,
+): Promise<Record<string, string>> {
+  const variables = extractTemplateVariables(templateContent);
+  const dataObj = {
+    var_taskDescription: taskDescription,
+    var_instructions: instructions,
+  };
+  const data = JSON.stringify(dataObj);
+
+  return collectVariables(
+    data,
+    options.cachePath ?? DEFAULT_CACHE_PATH,
+    variables,
+    templateContent,
+  );
+}
+
+function getProcessOptions(
+  options: AiAssistedTaskOptions,
+  basePath: string,
+  selectedFiles: string[],
+): AiAssistedTaskOptions {
+  return {
+    ...options,
+    path: basePath,
+    filter: options.invert ? undefined : selectedFiles,
+    exclude: options.invert ? selectedFiles : options.exclude,
+  };
+}
+
+async function generatePlanPrompt(
+  processedFiles: FileInfo[],
+  templateContent: string,
+  customData: Record<string, string>,
+  options: AiAssistedTaskOptions,
+  basePath: string,
+): Promise<string> {
+  const spinner = ora('Generating markdown...').start();
+  const markdownOptions: MarkdownOptions = {
+    noCodeblock: options.noCodeblock,
+    basePath,
+    customData,
+    lineNumbers: options.lineNumbers,
+  };
+
+  const planPrompt = await generateMarkdown(
+    processedFiles,
+    templateContent,
+    markdownOptions,
+  );
+  spinner.succeed('Plan prompt generated successfully');
+  return planPrompt;
+}
+
+async function generatePlan(
+  planPrompt: string,
+  modelKey: string,
+  options: AiAssistedTaskOptions,
+): Promise<string> {
+  const spinner = ora('Generating AI plan...').start();
+  const modelConfig = getModelConfig(modelKey);
+
+  let generatedPlan: string;
+  if (modelKey.includes('ollama')) {
+    generatedPlan = await generateAIResponse(planPrompt, {
+      maxCostThreshold: options.maxCostThreshold,
+      model: modelKey,
+      contextWindow: options.contextWindow,
+      maxTokens: options.maxTokens,
+      logAiInteractions: options.logAiInteractions,
+    });
+  } else {
+    generatedPlan = await generateAIResponse(
+      planPrompt,
+      {
+        maxCostThreshold: options.maxCostThreshold,
+        model: modelKey,
+        logAiInteractions: options.logAiInteractions,
+      },
+      modelConfig.temperature?.planningTemperature,
+    );
+  }
+
+  spinner.succeed('AI plan generated successfully');
+  return generatedPlan;
+}
+
+export async function continueTaskWorkflow(
+  options: AiAssistedTaskOptions,
+  basePath: string,
+  taskCache: TaskCache,
+  generatedPlan: string,
+  modelKey: string,
+) {
+  const spinner = ora();
+
+  const reviewedPlan = await reviewPlan(generatedPlan);
+
+  const codegenTemplatePath = options.diff
+    ? getTemplatePath('codegen-diff-prompt')
+    : getTemplatePath('codegen-prompt');
+
+  const codegenTemplateContent = await fs.readFile(
+    codegenTemplatePath,
+    'utf-8',
+  );
+  const codegenCustomData = await prepareCodegenCustomData(
+    codegenTemplateContent,
+    taskCache,
+    basePath,
+    reviewedPlan,
+    options,
+  );
+
+  spinner.start('Generating Codegen prompt...');
+  const codeGenPrompt = await generateCodegenPrompt(
+    options,
+    basePath,
+    taskCache,
+    codegenTemplateContent,
+    codegenCustomData,
+  );
+  spinner.succeed('Codegen prompt generated successfully');
+
+  const generatedCode = await generateCode(codeGenPrompt, modelKey, options);
+  const parsedResponse = parseAICodegenResponse(
+    generatedCode,
+    options.logAiInteractions,
+    options.diff,
+  );
+
+  if (options.dryRun) {
+    await handleDryRun(
+      basePath,
+      parsedResponse,
+      taskCache.getLastTaskData(basePath)?.taskDescription || '',
+    );
+  } else {
+    await applyCodeModifications(options, basePath, parsedResponse);
+  }
+
+  spinner.succeed('AI-assisted task completed! 🎉');
+}
+
+async function prepareCodegenCustomData(
+  codegenTemplateContent: string,
+  taskCache: TaskCache,
+  basePath: string,
+  reviewedPlan: string,
+  options: AiAssistedTaskOptions,
+): Promise<Record<string, string>> {
+  const codegenVariables = extractTemplateVariables(codegenTemplateContent);
+  const lastTaskData = taskCache.getLastTaskData(basePath);
+
+  const codegenDataObj = {
+    var_taskDescription: lastTaskData?.taskDescription || '',
+    var_instructions: lastTaskData?.instructions || '',
+    var_plan: reviewedPlan,
+  };
+
+  return collectVariables(
+    JSON.stringify(codegenDataObj),
+    options.cachePath ?? DEFAULT_CACHE_PATH,
+    codegenVariables,
+    codegenTemplateContent,
+  );
+}
+
+async function generateCodegenPrompt(
+  options: AiAssistedTaskOptions,
+  basePath: string,
+  taskCache: TaskCache,
+  codegenTemplateContent: string,
+  codegenCustomData: Record<string, string>,
+): Promise<string> {
+  const codegenMarkdownOptions: MarkdownOptions = {
+    noCodeblock: options.noCodeblock,
+    basePath,
+    customData: codegenCustomData,
+    lineNumbers: options.lineNumbers,
+  };
+
+  const processedFiles = await processFiles({
+    ...options,
+    path: basePath,
+    filter: options.invert
+      ? undefined
+      : taskCache.getLastTaskData(basePath)?.selectedFiles,
+    exclude: options.invert
+      ? taskCache.getLastTaskData(basePath)?.selectedFiles
+      : options.exclude,
+  });
+
+  return generateMarkdown(
+    processedFiles,
+    codegenTemplateContent,
+    codegenMarkdownOptions,
+  );
+}
+
+async function generateCode(
+  codeGenPrompt: string,
+  modelKey: string,
+  options: AiAssistedTaskOptions,
+): Promise<string> {
+  const spinner = ora('Generating AI Code Modifications...').start();
+  const modelConfig = getModelConfig(modelKey);
+
+  let generatedCode: string;
+  if (modelKey.includes('ollama')) {
+    generatedCode = await generateAIResponse(codeGenPrompt, {
+      maxCostThreshold: options.maxCostThreshold,
+      model: modelKey,
+      contextWindow: options.contextWindow,
+      maxTokens: options.maxTokens,
+      logAiInteractions: options.logAiInteractions,
+    });
+  } else {
+    generatedCode = await generateAIResponse(
+      codeGenPrompt,
+      {
+        maxCostThreshold: options.maxCostThreshold,
+        model: modelKey,
+        logAiInteractions: options.logAiInteractions,
+      },
+      modelConfig.temperature?.codegenTemperature,
+    );
+  }
+  spinner.succeed('AI Code Modifications generated successfully');
+  return generatedCode;
+}
+
+async function handleDryRun(
+  basePath: string,
+  parsedResponse: AIParsedResponse,
+  taskDescription: string,
+) {
+  ora().info(
+    chalk.yellow('Dry Run Mode: Generating output without applying changes'),
+  );
+
+  const outputPath = path.join(basePath, 'codewhisper-task-output.json');
+  await fs.writeJSON(
+    outputPath,
+    { taskDescription, parsedResponse },
+    { spaces: 2 },
+  );
+
+  console.log(chalk.green(`AI-generated output saved to: ${outputPath}`));
+  console.log(chalk.cyan('To apply these changes, run:'));
+  console.log(chalk.cyan(`npx codewhisper apply-task ${outputPath}`));
+
+  console.log('\nTask Summary:');
+  console.log(chalk.blue('Task Description:'), taskDescription);
+  console.log(chalk.blue('Branch Name:'), parsedResponse.gitBranchName);
+  console.log(chalk.blue('Commit Message:'), parsedResponse.gitCommitMessage);
+  console.log(chalk.blue('Files to be changed:'));
+  for (const file of parsedResponse.files) {
+    console.log(`  ${file.status}: ${file.path}`);
+  }
+  console.log(chalk.blue('Summary:'), parsedResponse.summary);
+  console.log(chalk.blue('Potential Issues:'), parsedResponse.potentialIssues);
+}
+
+async function applyCodeModifications(
+  options: AiAssistedTaskOptions,
+  basePath: string,
+  parsedResponse: AIParsedResponse,
+) {
+  const spinner = ora('Applying AI Code Modifications...').start();
+
+  try {
+    const actualBranchName = await ensureBranch(
+      basePath,
+      parsedResponse.gitBranchName,
+      { issueNumber: options.issueNumber },
+    );
+    await applyChanges({ basePath, parsedResponse, dryRun: false });
+
+    if (options.autoCommit) {
+      const git = simpleGit(basePath);
+      await git.add('.');
+      const commitMessage = options.issueNumber
+        ? `${parsedResponse.gitCommitMessage} (Closes #${options.issueNumber})`
+        : parsedResponse.gitCommitMessage;
+      await git.commit(commitMessage);
+      spinner.succeed(
+        `AI Code Modifications applied and committed to branch: ${actualBranchName}`,
+      );
+    } else {
+      spinner.succeed(
+        `AI Code Modifications applied to branch: ${actualBranchName}`,
+      );
+      console.log(chalk.green('Changes have been applied but not committed.'));
+      console.log(
+        chalk.yellow(
+          'Please review the changes in your IDE before committing.',
+        ),
+      );
+      console.log(
+        chalk.cyan('To commit the changes, use the following commands:'),
+      );
+      console.log(chalk.cyan('  git add .'));
+      console.log(
+        chalk.cyan(
+          `  git commit -m "${parsedResponse.gitCommitMessage}${options.issueNumber ? ` (Closes #${options.issueNumber})` : ''}"`,
+        ),
+      );
+    }
+  } catch (error) {
+    spinner.fail('Error applying AI Code Modifications');
+    console.error(
+      chalk.red('Failed to create branch or apply changes:'),
+      error instanceof Error ? error.message : String(error),
+    );
+    console.log(
+      chalk.yellow('Please check your Git configuration and try again.'),
     );
     process.exit(1);
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@ import fs from 'fs-extra';
 import ora from 'ora';
 import { applyTask } from '../ai/apply-task';
 import { getModelConfig, getModelNames } from '../ai/model-config';
+import { redoLastTask } from '../ai/redo-task';
 import { runAIAssistedTask } from '../ai/task-workflow';
 import { processFiles } from '../core/file-processor';
 import { generateMarkdown } from '../core/markdown-generator';
@@ -147,8 +148,16 @@ export function cli(_args: string[]) {
     .option('--auto-commit', 'Automatically commit changes', false)
     .option('--github-issue', 'Use GitHub issue for task input', false)
     .option('--undo', 'Undo the last AI-assisted task')
+    .option('--redo', 'Redo the last task for the specified path', false)
     .action(async (options) => {
-      if (options.undo) {
+      if (options.redo) {
+        try {
+          await redoLastTask(options);
+        } catch (error) {
+          console.error(chalk.red('Error redoing task:'), error);
+          process.exit(1);
+        }
+      } else if (options.undo) {
         try {
           await undoTaskChanges({ path: options.path || '.' });
         } catch (error) {

--- a/src/git/apply-changes.ts
+++ b/src/git/apply-changes.ts
@@ -72,7 +72,9 @@ async function applyFileChange(
             const currentContent = await fs.readFile(fullPath, 'utf-8');
             const updatedContent = applyPatch(currentContent, file.diff);
             if (updatedContent === false) {
-              throw new Error(`Failed to apply patch to file: ${file.path}`);
+              throw new Error(
+                `Failed to apply patch to file: ${file.path}\n A common cause is the the file was not sent to the LLM and it hallucinated the content. Try running the task again (task --redo) and selecting the problemtic file.`,
+              );
             }
             await fs.writeFile(fullPath, updatedContent);
           } else if (file.content) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -156,3 +156,13 @@ export interface ModelTemperature {
 export interface UndoTaskOptions {
   path?: string;
 }
+
+export interface TaskData {
+  basePath: string;
+  selectedFiles: string[];
+  generatedPlan: string;
+  taskDescription: string;
+  instructions: string;
+  timestamp: number;
+  model: string;
+}

--- a/src/utils/task-cache.ts
+++ b/src/utils/task-cache.ts
@@ -1,0 +1,41 @@
+import path from 'node:path';
+import fs from 'fs-extra';
+import type { TaskData } from '../types';
+
+export class TaskCache {
+  private cacheFile: string;
+  private cache: Record<string, TaskData> = {};
+
+  constructor(cacheFilePath: string) {
+    this.cacheFile = cacheFilePath;
+    this.loadCache();
+  }
+
+  private loadCache(): void {
+    if (fs.existsSync(this.cacheFile)) {
+      this.cache = fs.readJSONSync(this.cacheFile);
+    }
+  }
+
+  private saveCache(): void {
+    fs.writeJSONSync(this.cacheFile, this.cache);
+  }
+
+  setTaskData(
+    basePath: string,
+    data: Omit<TaskData, 'basePath' | 'timestamp'>,
+  ): void {
+    const key = this.getKey(basePath);
+    this.cache[key] = { ...data, basePath, timestamp: Date.now() };
+    this.saveCache();
+  }
+
+  getLastTaskData(basePath: string): TaskData | null {
+    const key = this.getKey(basePath);
+    return this.cache[key] || null;
+  }
+
+  private getKey(basePath: string): string {
+    return path.resolve(basePath);
+  }
+}

--- a/src/utils/task-cache.ts
+++ b/src/utils/task-cache.ts
@@ -1,3 +1,4 @@
+import os from 'node:os';
 import path from 'node:path';
 import fs from 'fs-extra';
 import type { TaskData } from '../types';
@@ -6,11 +7,13 @@ export class TaskCache {
   private cacheFile: string;
   private cache: Record<string, TaskData> = {};
 
-  constructor(cacheFilePath: string) {
-    this.cacheFile = cacheFilePath;
+  constructor(projectPath: string) {
+    const cacheDir = path.join(os.homedir(), '.codewhisper');
+    fs.ensureDirSync(cacheDir);
+    const projectHash = Buffer.from(projectPath).toString('base64');
+    this.cacheFile = path.join(cacheDir, `${projectHash}-task-cache.json`);
     this.loadCache();
   }
-
   private loadCache(): void {
     if (fs.existsSync(this.cacheFile)) {
       this.cache = fs.readJSONSync(this.cacheFile);

--- a/tests/unit/redo-task.test.ts
+++ b/tests/unit/redo-task.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { confirm } from '@inquirer/prompts';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getModelConfig } from '../../src/ai/model-config';
@@ -17,7 +18,7 @@ vi.mock('../../src/ai/task-workflow');
 
 describe('redoLastTask', () => {
   const mockOptions = {
-    path: '/test/path',
+    path: path.join('/', 'test', 'path'),
     model: 'test-model',
   } as AiAssistedTaskOptions;
 
@@ -67,7 +68,7 @@ describe('redoLastTask', () => {
 
     expect(continueTaskWorkflow).toHaveBeenCalledWith(
       expect.objectContaining({ model: 'last-model' }),
-      '/test/path',
+      path.join('/', 'test', 'path'),
       expect.any(Object),
       'Last generated plan',
       'last-model',
@@ -93,7 +94,7 @@ describe('redoLastTask', () => {
     expect(selectModelPrompt).toHaveBeenCalled();
     expect(continueTaskWorkflow).toHaveBeenCalledWith(
       expect.objectContaining({ model: 'new-model' }),
-      '/test/path',
+      path.join('/', 'test', 'path'),
       expect.any(Object),
       'Last generated plan',
       'new-model',
@@ -117,7 +118,7 @@ describe('redoLastTask', () => {
 
     expect(selectFilesPrompt).toHaveBeenCalled();
     expect(mockTaskCache.setTaskData).toHaveBeenCalledWith(
-      '/test/path',
+      path.join('/', 'test', 'path'),
       expect.objectContaining({
         selectedFiles: ['new-file1.ts', 'new-file2.ts'],
       }),

--- a/tests/unit/redo-task.test.ts
+++ b/tests/unit/redo-task.test.ts
@@ -68,7 +68,7 @@ describe('redoLastTask', () => {
 
     expect(continueTaskWorkflow).toHaveBeenCalledWith(
       expect.objectContaining({ model: 'last-model' }),
-      path.join('/', 'test', 'path'),
+      expect.stringMatching(/[\\\/]test[\\\/]path$/),
       expect.any(Object),
       'Last generated plan',
       'last-model',
@@ -94,7 +94,7 @@ describe('redoLastTask', () => {
     expect(selectModelPrompt).toHaveBeenCalled();
     expect(continueTaskWorkflow).toHaveBeenCalledWith(
       expect.objectContaining({ model: 'new-model' }),
-      path.join('/', 'test', 'path'),
+      expect.stringMatching(/[\\\/]test[\\\/]path$/),
       expect.any(Object),
       'Last generated plan',
       'new-model',
@@ -118,7 +118,7 @@ describe('redoLastTask', () => {
 
     expect(selectFilesPrompt).toHaveBeenCalled();
     expect(mockTaskCache.setTaskData).toHaveBeenCalledWith(
-      path.join('/', 'test', 'path'),
+      expect.stringMatching(/[\\\/]test[\\\/]path$/),
       expect.objectContaining({
         selectedFiles: ['new-file1.ts', 'new-file2.ts'],
       }),

--- a/tests/unit/redo-task.test.ts
+++ b/tests/unit/redo-task.test.ts
@@ -1,0 +1,126 @@
+import { confirm } from '@inquirer/prompts';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getModelConfig } from '../../src/ai/model-config';
+import { redoLastTask } from '../../src/ai/redo-task';
+import { continueTaskWorkflow } from '../../src/ai/task-workflow';
+import { selectFilesPrompt } from '../../src/interactive/select-files-prompt';
+import { selectModelPrompt } from '../../src/interactive/select-model-prompt';
+import type { AiAssistedTaskOptions } from '../../src/types';
+import { TaskCache } from '../../src/utils/task-cache';
+
+vi.mock('@inquirer/prompts');
+vi.mock('../../src/utils/task-cache');
+vi.mock('../../src/interactive/select-model-prompt');
+vi.mock('../../src/interactive/select-files-prompt');
+vi.mock('../../src/ai/model-config');
+vi.mock('../../src/ai/task-workflow');
+
+describe('redoLastTask', () => {
+  const mockOptions = {
+    path: '/test/path',
+    model: 'test-model',
+  } as AiAssistedTaskOptions;
+
+  const mockLastTaskData = {
+    selectedFiles: ['file1.ts', 'file2.ts'],
+    generatedPlan: 'Last generated plan',
+    taskDescription: 'Last task description',
+    instructions: 'Last instructions',
+    model: 'last-model',
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should exit if no previous task is found', async () => {
+    const mockTaskCache = {
+      getLastTaskData: vi.fn().mockReturnValue(null),
+      setTaskData: vi.fn(),
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: explicit any is fine here
+    vi.mocked(TaskCache).mockImplementation(() => mockTaskCache as any);
+
+    const consoleSpy = vi.spyOn(console, 'log');
+    const processExitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+
+    await redoLastTask(mockOptions);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('No previous task found'),
+    );
+    expect(processExitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('should redo the last task without changes', async () => {
+    const mockTaskCache = {
+      getLastTaskData: vi.fn().mockReturnValue(mockLastTaskData),
+      setTaskData: vi.fn(),
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: explicit any is fine here
+    vi.mocked(TaskCache).mockImplementation(() => mockTaskCache as any);
+    vi.mocked(confirm).mockResolvedValue(false);
+
+    await redoLastTask(mockOptions);
+
+    expect(continueTaskWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'last-model' }),
+      '/test/path',
+      expect.any(Object),
+      'Last generated plan',
+      'last-model',
+    );
+  });
+
+  it('should allow changing the model', async () => {
+    const mockTaskCache = {
+      getLastTaskData: vi.fn().mockReturnValue(mockLastTaskData),
+      setTaskData: vi.fn(),
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: explicit any is fine here
+    vi.mocked(TaskCache).mockImplementation(() => mockTaskCache as any);
+    vi.mocked(confirm).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    vi.mocked(selectModelPrompt).mockResolvedValue('new-model');
+    vi.mocked(getModelConfig).mockReturnValue({
+      modelName: 'New Model',
+      // biome-ignore lint/suspicious/noExplicitAny: explicit any is fine here
+    } as any);
+
+    await redoLastTask(mockOptions);
+
+    expect(selectModelPrompt).toHaveBeenCalled();
+    expect(continueTaskWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'new-model' }),
+      '/test/path',
+      expect.any(Object),
+      'Last generated plan',
+      'new-model',
+    );
+  });
+
+  it('should allow changing file selection', async () => {
+    const mockTaskCache = {
+      getLastTaskData: vi.fn().mockReturnValue(mockLastTaskData),
+      setTaskData: vi.fn(),
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: explicit any is fine here
+    vi.mocked(TaskCache).mockImplementation(() => mockTaskCache as any);
+    vi.mocked(confirm).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    vi.mocked(selectFilesPrompt).mockResolvedValue([
+      'new-file1.ts',
+      'new-file2.ts',
+    ]);
+
+    await redoLastTask(mockOptions);
+
+    expect(selectFilesPrompt).toHaveBeenCalled();
+    expect(mockTaskCache.setTaskData).toHaveBeenCalledWith(
+      '/test/path',
+      expect.objectContaining({
+        selectedFiles: ['new-file1.ts', 'new-file2.ts'],
+      }),
+    );
+  });
+});


### PR DESCRIPTION
This PR introduces a new 'redo' feature for AI-assisted tasks in CodeWhisper. This enhancement allows users to easily restart their last task from the review plan stage, providing more flexibility and efficiency in the AI-assisted coding process.

Key changes:
1. Implemented a new `redoLastTask` function in `src/ai/redo-task.ts`.
2. Updated `task-workflow.ts` to support the redo functionality.
3. Added a new `--redo` option to the CLI command in `src/cli/index.ts`.
4. Introduced `TaskCache` class for storing and retrieving task data.
5. Updated existing tests and added new unit tests for the redo feature.

New features:
- Users can now redo their last task using the `--redo` flag.
- Allows users to fine-tune their plan to improve results
- Option to change the AI model or file selection when redoing a task.
- Cached task data (including selected files, generated plan, task description, and instructions) is used for redo operations.

This feature improves the user experience by allowing quick iterations on AI-assisted tasks without the need to manually re-enter task details or file selections. It's particularly useful for refining AI-generated plans or trying different AI models for the same task.

Closes: #61 